### PR TITLE
Rework nightly workflow into more general release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,7 @@ jobs:
     - name: Create AppImage
       env:
         LD_BIN: ${{ steps.install-linuxdeploy.outputs.linuxdeploy }}
-        LDAI_UPDATE_INFORMATION: "gh-releases-zsync|${{ github.repository_owner }}|Cacoco|${{ env.UPDATE_TAG }}|cacoco-*-linux.AppImage.zsync"
+        LDAI_UPDATE_INFORMATION: "gh-releases-zsync|${{ github.repository_owner }}|Cacoco|${{ env.UPDATE_TAG }}|cacoco-*-linux-x86_64.AppImage.zsync"
         LDAI_VERSION: ${{ env.APPIMAGE_VERSION }}
         LDAI_OUTPUT: ${{ env.ARTIFACT_NAME }}
       run: |


### PR DESCRIPTION
This PR adds a 3rd trigger to the nightly release workflow in addition to the current manual and schedule triggers. Now, when a release is published, build will be created and uploaded to the release, using the tag as a version name. Currently, macOS builds are excluded from this, since the ones created by this workflow aren't packaged properly for actual releases yet.

There's also one final-really-for-real-this-time fix for the update info in the appimages.

Here's an example of the assets uploaded to a release tagged `0.9.1`
https://github.com/electricbrass/Cacoco/releases/tag/0.9.1