### PR TITLE
Center align STBAR in Vanilla template using corrected bitflag offsets.

### DIFF
--- a/assets/templates/classicSTBAR.json
+++ b/assets/templates/classicSTBAR.json
@@ -34,9 +34,9 @@
         "children": [
           {
             "graphic": {
-              "x": 0,
+              "x": 160,
               "y": 0,
-              "alignment": 0,
+              "alignment": 49,
               "translucency": false,
               "patch": "STBAR",
               "width": 0,


### PR DESCRIPTION
Now that the bitflags are fixed, this can be done. Closes #27.