### PR TITLE
Rework port adding section of settings

### DIFF
--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -406,7 +406,7 @@ pub fn draw_settings_window(
 
                                                 if let Some(path) = dialog.pick_file() {
                                                     let path_str = path.to_string_lossy().into_owned();
-                                                    if (port.name.is_empty())
+                                                    if port.name.is_empty()
                                                     {
                                                         port.name = SourcePortConfig::infer_name(&path_str);
                                                     }


### PR DESCRIPTION
<img width="853" height="442" alt="image" src="https://github.com/user-attachments/assets/5cde1dc7-11bc-4402-989a-960297483332" />

Now the "Add Port" button adds an empty port to the list, and a browse button is next to the path/command input. This, in my opinion, makes it more intuitive for ports that are launched through some other program such as flatpak or dosbox, as well as allowing reopening the file dialog for a port if its location has changed, without needing to type it in or delete and re-add it.