### PR TITLE
[Resource] Handle empty/null patches as like in Eviternity II's `STARMS` in a smarter way.

### DIFF
--- a/src/conditions.rs
+++ b/src/conditions.rs
@@ -60,9 +60,10 @@ fn check_single(condition: &ConditionDef, state: &PreviewState, assets: &AssetSt
 
         PatchEmpty | PatchNotEmpty => {
             let patch_name = condition.param_string.as_deref().unwrap_or("");
-
             let id = AssetId::new(patch_name);
-            let exists = assets.textures.contains_key(&id);
+
+            let is_sentinel = assets.offsets.get(&id) == Some(&(32767, 32767));
+            let exists = assets.textures.contains_key(&id) && !is_sentinel;
 
             if condition.condition == PatchEmpty {
                 !exists

--- a/src/render/graphic.rs
+++ b/src/render/graphic.rs
@@ -22,6 +22,10 @@ pub(super) fn draw_simple_graphic_patch(
     alpha: f32,
     crop: &Option<CropDef>,
 ) {
+    if ctx.assets.offsets.get(&patch_id) == Some(&(32767, 32767)) {
+        return;
+    }
+
     if let Some(tex) = ctx.assets.textures.get(&patch_id) {
         let mut size = tex.size_vec2();
         let (base_scale_x, base_scale_y) = ctx.get_native_scale_factor();

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -114,9 +114,6 @@ pub fn draw_element_wrapper(
     }
 
     let mut alpha = if !visible_in_game { 0.30 } else { 1.0 };
-    if common.translucency {
-        alpha *= 0.5;
-    }
 
     let is_hovered_branch = ctx
         .state
@@ -168,6 +165,12 @@ pub fn draw_element_wrapper(
     let should_render_content = match ctx.pass {
         RenderPass::Background => true,
         RenderPass::Foreground => is_selected_branch,
+    };
+
+    let alpha = if common.translucency {
+        alpha * 0.66
+    } else {
+        alpha
     };
 
     if should_render_content {

--- a/src/render/patch.rs
+++ b/src/render/patch.rs
@@ -17,7 +17,12 @@ pub fn decode_doom_patch(
         return None;
     }
 
+    if width == 0 || height == 0 {
+        return Some((0, 0, 32767, 32767, vec![]));
+    }
+
     let mut pixels = vec![0u8; (width * height * 4) as usize];
+    let mut pixels_written = 0;
 
     let col_offsets_start = 8;
     let col_offsets_end = 8 + (width as usize * 4);
@@ -58,12 +63,18 @@ pub fn decode_doom_patch(
                         pixels[pixel_idx + 1] = color.g();
                         pixels[pixel_idx + 2] = color.b();
                         pixels[pixel_idx + 3] = 255;
+                        pixels_written += 1;
                     }
                 }
             }
             cursor += 1;
         }
     }
+
+    if pixels_written == 0 {
+        return Some((0, 0, 32767, 32767, vec![]));
+    }
+
     Some((width, height, left_offset, top_offset, pixels))
 }
 

--- a/src/ui/resource_manager.rs
+++ b/src/ui/resource_manager.rs
@@ -60,8 +60,9 @@ pub fn draw_resource_manager(ctx: &egui::Context, app: &mut CacocoApp) {
 
                     if app.config.resource_paths.is_empty() {
                         ui.vertical_centered(|ui| {
-                            ui.add_space(20.0);
+                            ui.add_space(5.0);
                             ui.label(egui::RichText::new("No resources loaded.").weak().italics());
+                            ui.add_space(1.0);
                         });
                     } else {
                         let total_w = ui.available_width();
@@ -100,6 +101,7 @@ pub fn draw_resource_manager(ctx: &egui::Context, app: &mut CacocoApp) {
                                 }
                             });
                         }
+                        ui.add_space(-2.0);
                     }
                 });
 

--- a/src/wad/mod.rs
+++ b/src/wad/mod.rs
@@ -184,7 +184,11 @@ pub fn load_wad_into_store(
             if let Some((width, height, left, top, pixels)) =
                 patch::decode_doom_patch(&lump_data, &assets.palette)
             {
-                if width <= 2048 && height <= 2048 {
+                if width == 0 && height == 0 {
+                    let id = crate::assets::AssetId::new(&name);
+                    assets.load_rgba(ctx, &name, 1, 1, &[0, 0, 0, 0]);
+                    assets.offsets.insert(id, (32767, 32767));
+                } else if width <= 2048 && height <= 2048 {
                     assets.load_rgba_with_offset(ctx, &name, width, height, left, top, &pixels);
                 }
             } else if size == 4096 {
@@ -250,7 +254,12 @@ pub fn deep_search_iwad(
                 if let Some((width, height, left, top, pixels)) =
                     patch::decode_doom_patch(&lump_data, &assets.palette)
                 {
-                    if width <= 2048 && height <= 2048 {
+                    if width == 0 && height == 0 {
+                        let id = crate::assets::AssetId::new(&name);
+                        assets.load_rgba(ctx, &name, 1, 1, &[0, 0, 0, 0]);
+                        assets.offsets.insert(id, (32767, 32767));
+                        found.insert(name.clone());
+                    } else if width <= 2048 && height <= 2048 {
                         assets.load_rgba_with_offset(ctx, &name, width, height, left, top, &pixels);
                         found.insert(name.clone());
                     }


### PR DESCRIPTION
Closes #93.